### PR TITLE
Some minor features added, a few tweaks and a bug corrected

### DIFF
--- a/corepost/convert.py
+++ b/corepost/convert.py
@@ -8,6 +8,7 @@ for JSON/XML/YAML output
 
 import collections
 import logging
+import json
 from UserDict import DictMixin
 from twisted.python import log
 
@@ -15,8 +16,8 @@ advanced_json = False
 try:
     import jsonpickle
     advanced_json = True
-except ImportError:
-    import json
+except ImportError: pass
+
 
 primitives = (int, long, float, bool, str,unicode)
 

--- a/corepost/convert.py
+++ b/corepost/convert.py
@@ -7,27 +7,40 @@ for JSON/XML/YAML output
 '''
 
 import collections
+import logging
 from UserDict import DictMixin
+from twisted.python import log
+
+advanced_json = False
+try:
+    import jsonpickle
+    advanced_json = True
+except ImportError:
+    import json
 
 primitives = (int, long, float, bool, str,unicode)
 
 def convertForSerialization(obj):
     """Converts anything (clas,tuples,list) to the safe serializable equivalent"""
-    if type(obj) in primitives:
+    try:
+        if type(obj) in primitives:
         # no conversion
-        return obj 
-    elif isinstance(obj, dict) or isinstance(obj,DictMixin):
-        return traverseDict(obj)
-    elif isClassInstance(obj):
-        return convertClassToDict(obj)
-    elif isinstance(obj,collections.Iterable) and not isinstance(obj,str):
-        # iterable
-        values = []
-        for val in obj:
-            values.append(convertForSerialization(val))
-        return values
-    else:
-        # return as-is
+            return obj 
+        elif isinstance(obj, dict) or isinstance(obj,DictMixin):
+            return traverseDict(obj)
+        elif isClassInstance(obj):
+            return convertClassToDict(obj)
+        elif isinstance(obj,collections.Iterable) and not isinstance(obj,str):
+            # iterable
+            values = []
+            for val in obj:
+                values.append(convertForSerialization(val))
+            return values
+        else:
+            # return as-is
+            return obj
+    except AttributeError as ex:
+        log.msg(ex,logLevel=logging.WARN)
         return obj
 
 def convertClassToDict(clazz):
@@ -48,6 +61,19 @@ def traverseDict(dictObject):
         newDict[prop] = convertForSerialization(val)
     
     return newDict
+
+
+def convertToJson(obj):
+    """Converts to JSON, including Python classes that are not JSON serializable by default"""
+    if advanced_json:
+        try:
+            return jsonpickle.encode(obj, unpicklable=False)
+        except Exception as ex:
+            raise RuntimeError(str(ex))
+    try:
+        return json.dumps(obj)
+    except Exception as ex:
+        raise RuntimeError(str(ex))
     
 def generateXml(obj):
     """Generates basic XML from an object that has already been converted for serialization"""

--- a/corepost/enums.py
+++ b/corepost/enums.py
@@ -4,20 +4,26 @@ Common enums
 @author: jacekf
 '''
 
+
 class Http:
     """Enumerates HTTP methods"""
     GET = "GET"
     POST = "POST"
     PUT = "PUT"
     DELETE = "DELETE"
+    OPTIONS = "OPTIONS"
+    HEAD = "HEAD"
+    PATCH = "PATCH"
+
 
 class HttpHeader:
     """Enumerates common HTTP headers"""
     CONTENT_TYPE = "content-type"
     ACCEPT = "accept"
 
+
 class MediaType:
-    """Enumerates media types"""    
+    """Enumerates media types"""
     WILDCARD = "*/*"
     APPLICATION_XML = "application/xml"
     APPLICATION_ATOM_XML = "application/atom+xml"

--- a/corepost/routing.py
+++ b/corepost/routing.py
@@ -380,19 +380,20 @@ class RequestRouter:
         '''Automatically parses JSON,XML,YAML if present'''
         if request.method in (Http.POST,Http.PUT) and HttpHeader.CONTENT_TYPE in request.received_headers.keys():
             contentType = request.received_headers["content-type"]
+            data = request.content.read()
             if contentType == MediaType.APPLICATION_JSON:
                 try:
-                    request.json = json.loads(request.content.read())
+                    request.json = json.loads(data) if data else {}
                 except Exception as ex:
                     raise TypeError("Unable to parse JSON body: %s" % ex)
             elif contentType in (MediaType.APPLICATION_XML,MediaType.TEXT_XML):
                 try: 
-                    request.xml = ElementTree.XML(request.content.read())
+                    request.xml = ElementTree.XML(data)
                 except Exception as ex:
                     raise TypeError("Unable to parse XML body: %s" % ex)
             elif contentType == MediaType.TEXT_YAML:
                 try: 
-                    request.yaml = yaml.safe_load(request.content.read())
+                    request.yaml = yaml.safe_load(data)
                 except Exception as ex:
                     raise TypeError("Unable to parse YAML body: %s" % ex)
 

--- a/corepost/routing.py
+++ b/corepost/routing.py
@@ -17,6 +17,7 @@ from twisted.web.http import parse_qs
 from twisted.python import log
 import re, copy, exceptions, yaml,json, logging
 from xml.etree import ElementTree
+import uuid
 
 advanced_json = False
 try:
@@ -28,9 +29,9 @@ except ImportError: pass
 class UrlRouter:
     ''' Common class for containing info related to routing a request to a function '''
     
-    __urlMatcher = re.compile(r"<(int|float|):?([^/]+)>")
-    __urlRegexReplace = {"":r"(?P<arg>([^/]+))","int":r"(?P<arg>\d+)","float":r"(?P<arg>\d+.?\d*)"}
-    __typeConverters = {"int":int,"float":float}
+    __urlMatcher = re.compile(r"<(int|float|uuid|):?([^/]+)>")
+    __urlRegexReplace = {"":r"(?P<arg>([^/]+))","int":r"(?P<arg>\d+)","float":r"(?P<arg>\d+.?\d*)","uuid":r"(?P<arg>[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})"}
+    __typeConverters = {"int":int,"float":float,"uuid":uuid.UUID}
     
     def __init__(self,f,url,methods,accepts,produces,cache):
         self.__f = f

--- a/corepost/utils.py
+++ b/corepost/utils.py
@@ -2,7 +2,7 @@
 Various CorePost utilities
 '''
 from inspect import getargspec
-import json
+
 
 def getMandatoryArgumentNames(f):
     '''Returns a tuple of the mandatory arguments required in a function'''
@@ -11,17 +11,12 @@ def getMandatoryArgumentNames(f):
         return args
     else:
         return args[0:len(args) - len(defaults)]
-    
+
+
 def getRouterKey(method,url):
     '''Returns the common key used to represent a function that a request can be routed to'''
     return "%s %s" % (method,url)
 
-def convertToJson(obj):
-    """Converts to JSON, including Python classes that are not JSON serializable by default"""
-    try:
-        return json.dumps(obj)
-    except Exception as ex:
-        raise RuntimeError(str(ex))
 
 def checkExpectedInterfaces(objects,expectedInterface):
     """Verifies that all the objects implement the expected interface"""
@@ -33,4 +28,3 @@ def safeDictUpdate(dictObject,key,value):
     """Only adds a key to a dictionary. If key exists, it leaves it untouched"""
     if key not in dictObject:
         dictObject[key] = value
-        


### PR DESCRIPTION
Hello!

I have been using Corepost for a bit now, and required a few additional features:
- handling of some other (standard) http verbs (OPTIONS, HEAD, PATCH)
- automatic 501 error handling in case of existing URL but with an unimplemented verb in the request

So I have added these if that is ok/ of any interest for you.
I also:
- added support for simplejson for more powerfull json serialization
- found a bug in the __registerRouters method , that would mangle the urls when __registerRouters gets called more than once (this was visible in unit test I did for a rest api I created, as any tests except for the first, for the same url/verb would fail).
- did a few tweaks here and there (see commit messages)

Thanks again for your great work, I have found corepost very nice and easy to use!
Cheers.
Mark
